### PR TITLE
feat: add session status popup to track per-recording pipeline progress

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,13 @@ const STATE = {
   PROCESSING: 'PROCESSING'
 }
 
+const STATUS_LABELS = {
+  transcribing:    'Transcribing...',
+  generating_note: 'Generating note...',
+  completed:       'Completed',
+  failed:          'Failed'
+}
+
 // ---------------------------------------------------------------------------
 // Module-level state
 // ---------------------------------------------------------------------------
@@ -35,6 +42,9 @@ let tempMp3Path = null
 let patientNameResolver = null
 let activeDoctorId = null
 let doctorPickerResolver = null
+let activeSessionDir = null
+let statusWin = null
+let sessionRecordings = []
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -78,7 +88,8 @@ const DEFAULT_SETTINGS = {
   autoRecord: false,
   manualDeviceSelection: true,
   selectedDeviceIndex: null,
-  doctors: []
+  doctors: [],
+  sessionCounter: 0
 }
 
 function readSettings() {
@@ -192,12 +203,25 @@ function sanitizeName(name) {
   return result || null
 }
 
+function createSessionFolder() {
+  const settings = readSettings()
+  const counter = (settings.sessionCounter || 0) + 1
+  const datestamp = new Date().toISOString().slice(0, 10)
+  const folderName = `${datestamp}(${counter})`
+  const sessionDir = path.join(CASES_DIR, folderName)
+  fs.mkdirSync(sessionDir, { recursive: true })
+  writeSettings({ ...settings, sessionCounter: counter })
+  log(`Session folder created: ${sessionDir}`)
+  return sessionDir
+}
+
 function buildCaseFolder(sanitizedName) {
   const datestamp = new Date().toISOString().slice(0, 10)
   const folderName = sanitizedName
     ? `${sanitizedName}_${datestamp}`
     : `recording_${datestamp}_${new Date().toISOString().slice(11, 19).replace(/:/g, '-')}`
-  const caseDir = path.join(CASES_DIR, folderName)
+  const baseDir = activeSessionDir || CASES_DIR
+  const caseDir = path.join(baseDir, folderName)
   fs.mkdirSync(caseDir, { recursive: true })
   return { caseDir, folderName }
 }
@@ -241,6 +265,7 @@ function spawnTranscription(mp3Path, transcriptDest, soapNotePath, caseTag, temp
       spawnSoapGeneration(transcriptDest, soapNotePath, caseTag, false, templatePath)
       spawnDocxConversion(transcriptDest, caseTag)
     } else {
+      if (caseTag) updateRecordingStatus(caseTag, 'failed')
       const stderr = stderrChunks.join('')
       if (/401|invalid.api.key|unauthorized/i.test(stderr)) {
         win.webContents.send('service-warning', {
@@ -262,6 +287,7 @@ function spawnTranscription(mp3Path, transcriptDest, soapNotePath, caseTag, temp
 
 function spawnSoapGeneration(transcriptAbsPath, soapNoteMdPath, caseTag, isRetry = false, templatePath = null) {
   const tag = caseTag ? `[${caseTag}] ` : ''
+  if (caseTag) updateRecordingStatus(caseTag, 'generating_note')
   const relTranscript = path.relative(NOTES_DIR, transcriptAbsPath).replace(/\\/g, '/')
   let prompt
   if (templatePath) {
@@ -304,6 +330,7 @@ function spawnSoapGeneration(transcriptAbsPath, soapNoteMdPath, caseTag, isRetry
         title: 'Claude usage limit reached',
         message: `Your recording has been saved. Notes could not be generated — try again once the limit resets.`
       })
+      if (caseTag) updateRecordingStatus(caseTag, 'failed')
       return
     }
     if (code === 0 && soapNoteMdPath) {
@@ -312,7 +339,10 @@ function spawnSoapGeneration(transcriptAbsPath, soapNoteMdPath, caseTag, isRetry
         spawnDocxConversion(soapNoteMdPath, caseTag)
       } else {
         log(`${tag}[soap] WARNING: claude exited 0 but SOAP note file not found at expected path: ${soapNoteMdPath}`)
+        if (caseTag) updateRecordingStatus(caseTag, 'failed')
       }
+    } else if (code !== 0) {
+      if (caseTag) updateRecordingStatus(caseTag, 'failed')
     }
   })
   claudeProc.on('error', err => {
@@ -335,8 +365,13 @@ function spawnDocxConversion(mdPath, caseTag) {
   proc.stderr.on('data', d => log(`${tag}[docx ERR] ${d.toString().trim()}`))
   proc.on('close', code => {
     log(`${tag}[docx] exited ${code}`)
-    if (code === 0 && path.basename(mdPath) !== 'transcript.md') {
-      notifyUser('SOAP note ready', `Case: ${caseTag || 'unknown'}`)
+    if (path.basename(mdPath) !== 'transcript.md') {
+      if (code === 0) {
+        notifyUser('SOAP note ready', `Case: ${caseTag || 'unknown'}`)
+        if (caseTag) updateRecordingStatus(caseTag, 'completed')
+      } else {
+        if (caseTag) updateRecordingStatus(caseTag, 'failed')
+      }
     }
   })
   proc.on('error', err => log(`${tag}[docx ERR] failed to spawn md_to_docx: ${err.message}`))
@@ -399,6 +434,41 @@ function copyDirSync(src, dest) {
     } else {
       fs.copyFileSync(srcPath, destPath)
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recording status tracking
+// ---------------------------------------------------------------------------
+
+function addRecordingEntry(caseTag, displayName) {
+  sessionRecordings.push({
+    caseTag,
+    displayName: displayName || 'Unnamed',
+    startedAt: Date.now(),
+    status: 'transcribing'
+  })
+  broadcastRecordingStatus()
+}
+
+function updateRecordingStatus(caseTag, status) {
+  const entry = sessionRecordings.find(r => r.caseTag === caseTag)
+  if (entry) {
+    entry.status = status
+    broadcastRecordingStatus()
+  }
+}
+
+function broadcastRecordingStatus() {
+  const payload = sessionRecordings.map(r => ({
+    ...r,
+    statusLabel: STATUS_LABELS[r.status] || r.status
+  }))
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('recording-status-update', payload)
+  }
+  if (statusWin && !statusWin.isDestroyed()) {
+    statusWin.webContents.send('recording-status-update', payload)
   }
 }
 
@@ -595,6 +665,8 @@ function registerIpcHandlers() {
       log(`Selected doctor ID: ${selectedId}`)
     }
 
+    activeSessionDir = createSessionFolder()
+    sessionRecordings = []
     setState(STATE.SESSION_ACTIVE)
     return { ok: true }
   })
@@ -607,6 +679,7 @@ function registerIpcHandlers() {
       doctorPickerResolver = null
     }
     activeDoctorId = null
+    activeSessionDir = null
     // If somehow recording when session is stopped, kill the process
     if (recordingProcess) {
       recordingProcess.kill()
@@ -618,6 +691,10 @@ function registerIpcHandlers() {
     }
     tempMp3Path = null
     patientNameResolver = null
+    if (statusWin && !statusWin.isDestroyed()) {
+      statusWin.close()
+    }
+    sessionRecordings = []
     setState(STATE.IDLE)
     return true
   })
@@ -669,6 +746,7 @@ function registerIpcHandlers() {
   ipcMain.handle('stop-recording', async () => {
     log('stop-recording')
 
+    let exitPromise = Promise.resolve()
     if (recordingProcess) {
       // Null recordingProcess BEFORE awaiting exit so the exit handler (registered in
       // start-recording) knows this is an intentional stop and doesn't fire the
@@ -685,20 +763,22 @@ function registerIpcHandlers() {
       } catch (e) {
         log(`stdin write failed (process may have already exited): ${e.message}`)
       }
-      await waitForExit(procToStop)
+      exitPromise = waitForExit(procToStop)
     } else {
       log('WARNING: stop-recording called but recordingProcess already gone')
     }
 
+    // Update UI immediately — don't wait for Python's WAV→MP3 conversion first.
+    // This stops the timer and shows PROCESSING state right when Save is clicked.
     setState(STATE.PROCESSING)
-
-    // Ask renderer to show the patient name form
     win.webContents.send('show-patient-form')
 
-    // Wait for the scribe to enter/skip the patient name
-    const name = await new Promise(resolve => {
-      patientNameResolver = resolve
-    })
+    // Wait for patient name entry and Python's WAV→MP3 conversion concurrently.
+    // The scribe can name the case while the conversion runs in the background.
+    const [name] = await Promise.all([
+      new Promise(resolve => { patientNameResolver = resolve }),
+      exitPromise
+    ])
 
     log(`Patient name: ${name || '(none)'}`)
 
@@ -720,6 +800,7 @@ function registerIpcHandlers() {
     }
     tempMp3Path = null
 
+    addRecordingEntry(folderName, name ? name.replace(/_/g, ' ') : null)
     spawnTranscription(mp3Dest, transcriptDest, soapNotePath, folderName, _stopTemplatePath)
 
     // Return to SESSION_ACTIVE so scribe can immediately start the next recording
@@ -768,13 +849,27 @@ function registerIpcHandlers() {
     if (recordingProcess) {
       const procToStop = recordingProcess
       recordingProcess = null
+      const mp3ToDelete = tempMp3Path
+      tempMp3Path = null
       try {
         procToStop.stdin.write('stop\n')
         procToStop.stdin.end()
       } catch (e) {
         log(`stdin write failed (process may have already exited): ${e.message}`)
       }
-      await waitForExit(procToStop)
+      // Update UI immediately — stop the timer without waiting for Python's conversion.
+      setState(STATE.SESSION_ACTIVE)
+      // Clean up temp files in background after Python exits.
+      // Also delete the WAV in case Python hadn't converted it yet.
+      waitForExit(procToStop).then(() => {
+        const wavPath = mp3ToDelete ? mp3ToDelete.replace('.mp3', '_tmp.wav') : null
+        for (const p of [mp3ToDelete, wavPath]) {
+          if (p && fs.existsSync(p)) {
+            try { fs.unlinkSync(p) } catch (e) { log(`Failed to delete temp file: ${e.message}`) }
+          }
+        }
+      }).catch(() => {})
+      return true
     }
 
     if (tempMp3Path && fs.existsSync(tempMp3Path)) {
@@ -1010,6 +1105,7 @@ function registerIpcHandlers() {
     const _uploadDoctor = (_uploadSettings.doctors || []).find(d => d.id === activeDoctorId)
     const _uploadTemplatePath = _uploadDoctor?.templatePath || null
 
+    addRecordingEntry(folderName, name ? name.replace(/_/g, ' ') : null)
     setState(STATE.PROCESSING)
     spawnTranscription(audioDest, transcriptDest, soapNotePath, folderName, _uploadTemplatePath)
 
@@ -1039,6 +1135,52 @@ function registerIpcHandlers() {
     copyDirSync(CLAUDE_CONFIG_SRC, path.join(NOTES_DIR, '.claude'))
     log(`Notes directory set to: ${NOTES_DIR}`)
     return { ok: true, path: NOTES_DIR }
+  })
+
+  // ---- get-session-recordings ----
+  ipcMain.handle('get-session-recordings', () => {
+    return sessionRecordings.map(r => ({
+      ...r,
+      statusLabel: STATUS_LABELS[r.status] || r.status
+    }))
+  })
+
+  // ---- open-status-window ----
+  ipcMain.handle('open-status-window', () => {
+    if (statusWin && !statusWin.isDestroyed()) {
+      statusWin.focus()
+      return
+    }
+    const mainBounds = win.getBounds()
+    const statusWidth = 300
+    const statusHeight = 380
+    const { workArea } = screen.getPrimaryDisplay()
+    let sx = mainBounds.x - statusWidth - 8
+    let sy = mainBounds.y
+    sx = Math.max(workArea.x, Math.min(sx, workArea.x + workArea.width - statusWidth))
+    sy = Math.max(workArea.y, Math.min(sy, workArea.y + workArea.height - statusHeight))
+    statusWin = new BrowserWindow({
+      width: statusWidth,
+      height: statusHeight,
+      x: sx,
+      y: sy,
+      frame: false,
+      resizable: false,
+      alwaysOnTop: true,
+      skipTaskbar: true,
+      webPreferences: {
+        preload: path.join(__dirname, 'preload.js'),
+        contextIsolation: true,
+        nodeIntegration: false
+      }
+    })
+    statusWin.loadFile(path.join(__dirname, 'renderer', 'status.html'))
+    statusWin.on('closed', () => { statusWin = null })
+  })
+
+  // ---- close-status-window ----
+  ipcMain.handle('close-status-window', () => {
+    if (statusWin && !statusWin.isDestroyed()) statusWin.close()
   })
 }
 

--- a/preload.js
+++ b/preload.js
@@ -34,10 +34,15 @@ contextBridge.exposeInMainWorld('api', {
 
   hideWindow:             ()   => ipcRenderer.invoke('hide-window'),
 
-  onStateChange:          (cb) => ipcRenderer.on('state-change',          (_, s)   => cb(s)),
-  onShowPatientForm:      (cb) => ipcRenderer.on('show-patient-form',     ()       => cb()),
-  onSetupWarning:         (cb) => ipcRenderer.on('setup-warning',         (_, msg) => cb(msg)),
-  onAutoStartRecording:   (cb) => ipcRenderer.on('auto-start-recording',  ()          => cb()),
-  onPickDoctor:           (cb) => ipcRenderer.on('pick-doctor',           (_, doctors) => cb(doctors)),
-  onServiceWarning:       (cb) => ipcRenderer.on('service-warning',       (_, data)    => cb(data))
+  getSessionRecordings:    ()   => ipcRenderer.invoke('get-session-recordings'),
+  openStatusWindow:        ()   => ipcRenderer.invoke('open-status-window'),
+  closeStatusWindow:       ()   => ipcRenderer.invoke('close-status-window'),
+
+  onStateChange:           (cb) => ipcRenderer.on('state-change',            (_, s)       => cb(s)),
+  onShowPatientForm:       (cb) => ipcRenderer.on('show-patient-form',       ()           => cb()),
+  onSetupWarning:          (cb) => ipcRenderer.on('setup-warning',           (_, msg)     => cb(msg)),
+  onAutoStartRecording:    (cb) => ipcRenderer.on('auto-start-recording',    ()           => cb()),
+  onPickDoctor:            (cb) => ipcRenderer.on('pick-doctor',             (_, doctors) => cb(doctors)),
+  onServiceWarning:        (cb) => ipcRenderer.on('service-warning',         (_, data)    => cb(data)),
+  onRecordingStatusUpdate: (cb) => ipcRenderer.on('recording-status-update', (_, data)    => cb(data))
 })

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -111,6 +111,11 @@
     <!-- Action buttons -->
     <div id="action-buttons"></div>
 
+    <!-- View Status bar (visible when session is active) -->
+    <div id="view-status-bar" class="hidden">
+      <button id="btn-view-status" class="link-btn">View Status</button>
+    </div>
+
     <!-- Upload patient name form (shown after file picked, no countdown) -->
     <div id="upload-form" class="hidden">
       <button id="btn-upload-close" class="upload-close-btn" title="Cancel">&#10005;</button>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -60,6 +60,7 @@ const notesDirPath      = document.getElementById('notes-dir-path')
 const btnChangeNotesDir = document.getElementById('btn-change-notes-dir')
 const folderSetup       = document.getElementById('folder-setup')
 const btnBrowseNotesDir = document.getElementById('btn-browse-notes-dir')
+const viewStatusBar     = document.getElementById('view-status-bar')
 
 // ---------------------------------------------------------------------------
 // Timer
@@ -68,6 +69,18 @@ const btnBrowseNotesDir = document.getElementById('btn-browse-notes-dir')
 let timerInterval = null
 let timerSeconds = 0
 
+function formatTime(secs) {
+  if (secs >= 3600) {
+    const h = String(Math.floor(secs / 3600)).padStart(2, '0')
+    const m = String(Math.floor((secs % 3600) / 60)).padStart(2, '0')
+    const s = String(secs % 60).padStart(2, '0')
+    return `${h}:${m}:${s}`
+  }
+  const m = String(Math.floor(secs / 60)).padStart(2, '0')
+  const s = String(secs % 60).padStart(2, '0')
+  return `${m}:${s}`
+}
+
 function startTimer() {
   timerSeconds = 0
   timerEl.textContent = '00:00'
@@ -75,9 +88,7 @@ function startTimer() {
   if (timerInterval) clearInterval(timerInterval)
   timerInterval = setInterval(() => {
     timerSeconds++
-    const m = String(Math.floor(timerSeconds / 60)).padStart(2, '0')
-    const s = String(timerSeconds % 60).padStart(2, '0')
-    timerEl.textContent = `${m}:${s}`
+    timerEl.textContent = formatTime(timerSeconds)
   }, 1000)
 }
 
@@ -101,9 +112,7 @@ function resumeTimer() {
   if (timerInterval) clearInterval(timerInterval)
   timerInterval = setInterval(() => {
     timerSeconds++
-    const m = String(Math.floor(timerSeconds / 60)).padStart(2, '0')
-    const s = String(timerSeconds % 60).padStart(2, '0')
-    timerEl.textContent = `${m}:${s}`
+    timerEl.textContent = formatTime(timerSeconds)
   }, 1000)
 }
 
@@ -125,6 +134,7 @@ function render(state) {
   patientForm.classList.add('hidden')
   uploadForm.classList.add('hidden')
   doctorPicker.classList.add('hidden')
+  viewStatusBar.classList.add('hidden')
 
   switch (state) {
     case STATE.IDLE: {
@@ -146,6 +156,7 @@ function render(state) {
       indicator.className = 'active'
       statusLabel.textContent = 'Session active'
       stopTimer()
+      viewStatusBar.classList.remove('hidden')
 
       const btnRec = makeButton('Start Recording', async () => {
         await api.startRecording()
@@ -167,6 +178,7 @@ function render(state) {
     case STATE.RECORDING: {
       indicator.className = 'pulsing'
       statusLabel.textContent = 'Recording...'
+      viewStatusBar.classList.remove('hidden')
       if (prevState === STATE.PAUSED) {
         resumeTimer()
       } else {
@@ -193,6 +205,7 @@ function render(state) {
     case STATE.PAUSED: {
       indicator.className = 'paused'
       statusLabel.textContent = 'Paused'
+      viewStatusBar.classList.remove('hidden')
       pauseTimer()
 
       const btnResume = makeButton('Resume', async () => {
@@ -215,6 +228,7 @@ function render(state) {
     case STATE.PROCESSING: {
       indicator.className = 'active'
       statusLabel.textContent = 'Processing...'
+      viewStatusBar.classList.remove('hidden')
       stopTimer()
 
       const btnDisabled = makeButton('Please wait...', null)
@@ -412,7 +426,7 @@ doctorInput.addEventListener('keydown', e => {
 
 function showSettings() {
   settingsOpen = true
-  ;[timerEl, configWarnings, actionButtons, uploadForm, patientForm, setupWarning, doctorPicker]
+  ;[timerEl, configWarnings, actionButtons, uploadForm, patientForm, setupWarning, doctorPicker, viewStatusBar]
     .forEach(el => { if (el) el.style.display = 'none' })
   settingsView.classList.remove('hidden')
   loadSettings()
@@ -421,7 +435,7 @@ function showSettings() {
 function hideSettings() {
   settingsOpen = false
   settingsView.classList.add('hidden')
-  ;[timerEl, configWarnings, actionButtons, uploadForm, patientForm, setupWarning, doctorPicker]
+  ;[timerEl, configWarnings, actionButtons, uploadForm, patientForm, setupWarning, doctorPicker, viewStatusBar]
     .forEach(el => { if (el) el.style.display = '' })
   render(currentRenderedState)
 }
@@ -660,7 +674,8 @@ const MAIN_CONTENT_ELS = [
   () => configWarnings,
   () => actionButtons,
   () => setupWarning,
-  () => serviceWarning
+  () => serviceWarning,
+  () => viewStatusBar
 ]
 
 function showFolderSetup() {
@@ -695,6 +710,11 @@ function registerAppListeners() {
   api.onAutoStartRecording(async () => {
     setTimeout(() => api.startRecording(), 500)
   })
+  api.onRecordingStatusUpdate(recordings => {
+    const btn = document.getElementById('btn-view-status')
+    if (btn) btn.textContent = recordings.length > 0 ? `View Status (${recordings.length})` : 'View Status'
+  })
+  document.getElementById('btn-view-status').addEventListener('click', () => api.openStatusWindow())
 }
 
 // ---------------------------------------------------------------------------

--- a/renderer/status.css
+++ b/renderer/status.css
@@ -1,0 +1,122 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: #1a1a1a;
+  color: #e0e0e0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 13px;
+  user-select: none;
+  -webkit-app-region: no-drag;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+#status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #2a2a2a;
+  flex-shrink: 0;
+}
+
+.header-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.icon-btn {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: #666;
+  font-size: 13px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.icon-btn:hover {
+  color: #fff;
+  background: #c0392b;
+}
+
+#recording-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+#no-recordings {
+  padding: 24px 16px;
+  text-align: center;
+  color: #555;
+  font-size: 12px;
+}
+
+.recording-item {
+  padding: 10px 16px;
+  border-bottom: 1px solid #222;
+}
+
+.recording-item:last-child {
+  border-bottom: none;
+}
+
+.recording-name {
+  font-size: 12px;
+  color: #ccc;
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.recording-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-transcribing .status-dot     { background: #7b5ea7; animation: pulse 1.4s ease-in-out infinite; }
+.status-transcribing span:last-child  { color: #9b7ec7; }
+
+.status-generating_note .status-dot     { background: #7b5ea7; animation: pulse 1.4s ease-in-out infinite; }
+.status-generating_note span:last-child  { color: #9b7ec7; }
+
+.status-completed .status-dot       { background: #1D9E75; }
+.status-completed span:last-child    { color: #1D9E75; }
+
+.status-failed .status-dot          { background: #c0392b; }
+.status-failed span:last-child       { color: #c0392b; }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.35; }
+}
+
+#recording-list::-webkit-scrollbar       { width: 4px; }
+#recording-list::-webkit-scrollbar-track { background: transparent; }
+#recording-list::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }

--- a/renderer/status.html
+++ b/renderer/status.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'">
+  <title>Session Status</title>
+  <link rel="stylesheet" href="status.css" />
+</head>
+<body>
+  <div id="app">
+    <div id="status-header">
+      <span class="header-title">Session Status</span>
+      <button id="btn-close" class="icon-btn" title="Close">&#10005;</button>
+    </div>
+    <div id="recording-list">
+      <div id="no-recordings">No recordings this session</div>
+    </div>
+  </div>
+  <script src="status.js"></script>
+</body>
+</html>

--- a/renderer/status.js
+++ b/renderer/status.js
@@ -1,0 +1,44 @@
+'use strict'
+
+function renderRecordings(recordings) {
+  const list = document.getElementById('recording-list')
+
+  if (!recordings || recordings.length === 0) {
+    list.innerHTML = '<div id="no-recordings">No recordings this session</div>'
+    return
+  }
+
+  list.innerHTML = ''
+  recordings.slice().reverse().forEach(rec => {
+    const item = document.createElement('div')
+    item.className = 'recording-item'
+
+    const nameRow = document.createElement('div')
+    nameRow.className = 'recording-name'
+    nameRow.textContent = rec.displayName
+    nameRow.title = rec.caseTag
+
+    const statusRow = document.createElement('div')
+    statusRow.className = `recording-status status-${rec.status}`
+
+    const dot = document.createElement('span')
+    dot.className = 'status-dot'
+
+    const label = document.createElement('span')
+    label.textContent = rec.statusLabel
+
+    statusRow.appendChild(dot)
+    statusRow.appendChild(label)
+    item.appendChild(nameRow)
+    item.appendChild(statusRow)
+    list.appendChild(item)
+  })
+}
+
+document.getElementById('btn-close').addEventListener('click', () => {
+  api.closeStatusWindow()
+})
+
+api.onRecordingStatusUpdate(renderRecordings)
+
+api.getSessionRecordings().then(renderRecordings).catch(console.error)

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -743,5 +743,27 @@ button.outline:hover { opacity: 0.85; }
   margin-top: 4px;
 }
 
+/* View status bar */
+#view-status-bar {
+  display: flex;
+  justify-content: center;
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  color: #1D9E75;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 2px 0;
+  text-decoration: underline;
+  width: auto;
+  opacity: 0.75;
+}
+
+.link-btn:hover {
+  opacity: 1;
+}
+
 /* Utility */
 .hidden { display: none !important; }


### PR DESCRIPTION
Adds a "View Status" link to the main popup (visible when a session is active) that opens a side panel window showing every recording in the session with its live pipeline stage — Transcribing, Generating note, Completed, or Failed.

- Track per-recording status in sessionRecordings[] array (cleared on new session)
- Instrument spawnTranscription, spawnSoapGeneration, spawnDocxConversion to update status at each stage and on failure
- Broadcast status updates to both the main popup and the status window via IPC
- New BrowserWindow (status.html/js/css) positioned beside the main popup, auto-closes when session ends
- Status count badge on the View Status button updates as recordings progress