### PR TITLE
Session wise folders

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ const STATE = {
 const STATUS_LABELS = {
   transcribing:    'Transcribing...',
   generating_note: 'Generating note...',
+  converting:      'Converting...',
   completed:       'Completed',
   failed:          'Failed'
 }
@@ -338,8 +339,24 @@ function spawnSoapGeneration(transcriptAbsPath, soapNoteMdPath, caseTag, isRetry
         log(`${tag}[soap] SOAP note confirmed: ${soapNoteMdPath}`)
         spawnDocxConversion(soapNoteMdPath, caseTag)
       } else {
-        log(`${tag}[soap] WARNING: claude exited 0 but SOAP note file not found at expected path: ${soapNoteMdPath}`)
-        if (caseTag) updateRecordingStatus(caseTag, 'failed')
+        // Top-level soap note missing — Claude may have created per-patient subfolders
+        const caseDir = path.dirname(soapNoteMdPath)
+        const patientFolders = detectPatientFolders(caseDir)
+        if (patientFolders.length > 0) {
+          log(`${tag}[soap] Multi-patient: ${patientFolders.length} patient(s) detected`)
+          const patients = patientFolders.map(pf => ({
+            name: pf.folderName.replace(/_\d{4}-\d{2}-\d{2}$/, '').replace(/_/g, ' '),
+            folderName: pf.folderName,
+            status: 'converting'
+          }))
+          if (caseTag) setRecordingPatients(caseTag, patients)
+          for (const pf of patientFolders) {
+            spawnDocxConversion(pf.soapNotePath, caseTag, pf.folderName)
+          }
+        } else {
+          log(`${tag}[soap] WARNING: claude exited 0 but no SOAP note found at ${soapNoteMdPath}`)
+          if (caseTag) updateRecordingStatus(caseTag, 'failed')
+        }
       }
     } else if (code !== 0) {
       if (caseTag) updateRecordingStatus(caseTag, 'failed')
@@ -353,7 +370,7 @@ function spawnSoapGeneration(transcriptAbsPath, soapNoteMdPath, caseTag, isRetry
   })
 }
 
-function spawnDocxConversion(mdPath, caseTag) {
+function spawnDocxConversion(mdPath, caseTag, patientFolderName = null) {
   const tag = caseTag ? `[${caseTag}] ` : ''
   log(`${tag}[docx] Converting: ${mdPath}`)
   const proc = spawn(PYTHON, [
@@ -368,9 +385,17 @@ function spawnDocxConversion(mdPath, caseTag) {
     if (path.basename(mdPath) !== 'transcript.md') {
       if (code === 0) {
         notifyUser('SOAP note ready', `Case: ${caseTag || 'unknown'}`)
-        if (caseTag) updateRecordingStatus(caseTag, 'completed')
+        if (patientFolderName) {
+          updatePatientStatus(caseTag, patientFolderName, 'completed')
+        } else if (caseTag) {
+          updateRecordingStatus(caseTag, 'completed')
+        }
       } else {
-        if (caseTag) updateRecordingStatus(caseTag, 'failed')
+        if (patientFolderName) {
+          updatePatientStatus(caseTag, patientFolderName, 'failed')
+        } else if (caseTag) {
+          updateRecordingStatus(caseTag, 'failed')
+        }
       }
     }
   })
@@ -459,10 +484,50 @@ function updateRecordingStatus(caseTag, status) {
   }
 }
 
+function setRecordingPatients(caseTag, patients) {
+  const entry = sessionRecordings.find(r => r.caseTag === caseTag)
+  if (entry) {
+    entry.patients = patients
+    broadcastRecordingStatus()
+  }
+}
+
+function updatePatientStatus(caseTag, patientFolderName, status) {
+  const entry = sessionRecordings.find(r => r.caseTag === caseTag)
+  if (!entry || !entry.patients) return
+  const patient = entry.patients.find(p => p.folderName === patientFolderName)
+  if (patient) {
+    patient.status = status
+    const allDone = entry.patients.every(p => p.status === 'completed' || p.status === 'failed')
+    if (allDone) {
+      entry.status = entry.patients.some(p => p.status === 'failed') ? 'failed' : 'completed'
+    }
+    broadcastRecordingStatus()
+  }
+}
+
+function detectPatientFolders(caseDir) {
+  const results = []
+  try {
+    for (const entry of fs.readdirSync(caseDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const subDir = path.join(caseDir, entry.name)
+      const soapNote = fs.readdirSync(subDir).find(f => f.endsWith('_soap_note.md'))
+      if (soapNote) {
+        results.push({ folderName: entry.name, soapNotePath: path.join(subDir, soapNote) })
+      }
+    }
+  } catch (e) {
+    log(`ERROR scanning patient folders in ${caseDir}: ${e.message}`)
+  }
+  return results
+}
+
 function broadcastRecordingStatus() {
   const payload = sessionRecordings.map(r => ({
     ...r,
-    statusLabel: STATUS_LABELS[r.status] || r.status
+    statusLabel: STATUS_LABELS[r.status] || r.status,
+    patients: r.patients ? r.patients.map(p => ({ ...p, statusLabel: STATUS_LABELS[p.status] || p.status })) : null
   }))
   if (win && !win.isDestroyed()) {
     win.webContents.send('recording-status-update', payload)
@@ -1141,7 +1206,8 @@ function registerIpcHandlers() {
   ipcMain.handle('get-session-recordings', () => {
     return sessionRecordings.map(r => ({
       ...r,
-      statusLabel: STATUS_LABELS[r.status] || r.status
+      statusLabel: STATUS_LABELS[r.status] || r.status,
+      patients: r.patients ? r.patients.map(p => ({ ...p, statusLabel: STATUS_LABELS[p.status] || p.status })) : null
     }))
   })
 

--- a/main.js
+++ b/main.js
@@ -384,10 +384,14 @@ function spawnDocxConversion(mdPath, caseTag, patientFolderName = null) {
     log(`${tag}[docx] exited ${code}`)
     if (path.basename(mdPath) !== 'transcript.md') {
       if (code === 0) {
-        notifyUser('SOAP note ready', `Case: ${caseTag || 'unknown'}`)
         if (patientFolderName) {
+          const entry = sessionRecordings.find(r => r.caseTag === caseTag)
+          const patient = entry?.patients?.find(p => p.folderName === patientFolderName)
+          notifyUser('SOAP note ready', patient?.name || patientFolderName.replace(/_/g, ' '))
           updatePatientStatus(caseTag, patientFolderName, 'completed')
         } else if (caseTag) {
+          const entry = sessionRecordings.find(r => r.caseTag === caseTag)
+          notifyUser('SOAP note ready', entry?.displayName || caseTag)
           updateRecordingStatus(caseTag, 'completed')
         }
       } else {
@@ -469,7 +473,7 @@ function copyDirSync(src, dest) {
 function addRecordingEntry(caseTag, displayName) {
   sessionRecordings.push({
     caseTag,
-    displayName: displayName || 'Unnamed',
+    displayName: displayName || (caseTag ? caseTag.replace(/_/g, ' ') : 'Unnamed'),
     startedAt: Date.now(),
     status: 'transcribing'
   })
@@ -507,18 +511,30 @@ function updatePatientStatus(caseTag, patientFolderName, status) {
 }
 
 function detectPatientFolders(caseDir) {
+  // Patient folders are siblings of caseDir inside the session folder, not children of it
+  const sessionDir = path.dirname(caseDir)
+
+  // Exclude known recording case folders and patient folders already attributed to prior recordings
+  const knownCaseTags = new Set(sessionRecordings.map(r => r.caseTag))
+  const claimedPatients = new Set()
+  sessionRecordings.forEach(r => {
+    if (r.patients) r.patients.forEach(p => claimedPatients.add(p.folderName))
+  })
+
   const results = []
   try {
-    for (const entry of fs.readdirSync(caseDir, { withFileTypes: true })) {
+    for (const entry of fs.readdirSync(sessionDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue
-      const subDir = path.join(caseDir, entry.name)
+      if (knownCaseTags.has(entry.name)) continue   // skip recording case folders
+      if (claimedPatients.has(entry.name)) continue  // skip patients of earlier recordings
+      const subDir = path.join(sessionDir, entry.name)
       const soapNote = fs.readdirSync(subDir).find(f => f.endsWith('_soap_note.md'))
       if (soapNote) {
         results.push({ folderName: entry.name, soapNotePath: path.join(subDir, soapNote) })
       }
     }
   } catch (e) {
-    log(`ERROR scanning patient folders in ${caseDir}: ${e.message}`)
+    log(`ERROR scanning patient folders in ${sessionDir}: ${e.message}`)
   }
   return results
 }

--- a/notes-claude/skills/generate-note/SKILL.md
+++ b/notes-claude/skills/generate-note/SKILL.md
@@ -138,8 +138,9 @@ PATIENTS=("<CASE_STEM>")
 2. For each patient, create a case folder and copy the full MP3, full transcript, and their transcript segment:
 
 ```bash
+SESSION_DIR=$(dirname "${CASE_DIR}")
 for PATIENT_NAME in <list of names>; do
-  PATIENT_CASE_DIR="${CASES_DIR}/${PATIENT_NAME}"
+  PATIENT_CASE_DIR="${SESSION_DIR}/${PATIENT_NAME}"
   mkdir -p "${PATIENT_CASE_DIR}"
 
   # Copy full original MP3 (if found)

--- a/renderer/status.css
+++ b/renderer/status.css
@@ -100,17 +100,72 @@ body {
   flex-shrink: 0;
 }
 
-.status-transcribing .status-dot     { background: #7b5ea7; animation: pulse 1.4s ease-in-out infinite; }
-.status-transcribing span:last-child  { color: #9b7ec7; }
+.status-transcribing .status-dot,
+.status-generating_note .status-dot  { background: #7b5ea7; animation: pulse 1.4s ease-in-out infinite; }
+.status-transcribing span:last-child,
+.status-generating_note span:last-child { color: #9b7ec7; }
 
-.status-generating_note .status-dot     { background: #7b5ea7; animation: pulse 1.4s ease-in-out infinite; }
-.status-generating_note span:last-child  { color: #9b7ec7; }
+.status-converting .status-dot       { background: #c07a00; animation: pulse 1.4s ease-in-out infinite; }
+.status-converting span:last-child    { color: #e09030; }
 
-.status-completed .status-dot       { background: #1D9E75; }
-.status-completed span:last-child    { color: #1D9E75; }
+.status-completed .status-dot        { background: #1D9E75; }
+.status-completed span:last-child     { color: #1D9E75; }
 
-.status-failed .status-dot          { background: #c0392b; }
-.status-failed span:last-child       { color: #c0392b; }
+.status-failed .status-dot           { background: #c0392b; }
+.status-failed span:last-child        { color: #c0392b; }
+
+/* Multi-patient header */
+.recording-header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 8px;
+}
+
+.patient-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #252525;
+  border: 1px solid #3a3a3a;
+  color: #888;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  flex-shrink: 0;
+}
+
+/* Patient sub-rows */
+.patient-row {
+  padding: 5px 0 5px 12px;
+  border-left: 2px solid #2a2a2a;
+  margin-left: 4px;
+  margin-bottom: 5px;
+}
+
+.patient-row:last-child {
+  margin-bottom: 0;
+}
+
+.patient-name {
+  font-size: 11px;
+  color: #bbb;
+  margin-bottom: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.patient-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+}
 
 @keyframes pulse {
   0%, 100% { opacity: 1; }

--- a/renderer/status.js
+++ b/renderer/status.js
@@ -13,24 +13,69 @@ function renderRecordings(recordings) {
     const item = document.createElement('div')
     item.className = 'recording-item'
 
-    const nameRow = document.createElement('div')
-    nameRow.className = 'recording-name'
-    nameRow.textContent = rec.displayName
-    nameRow.title = rec.caseTag
+    if (rec.patients && rec.patients.length > 0) {
+      // Multi-patient hierarchical view
+      const header = document.createElement('div')
+      header.className = 'recording-header'
 
-    const statusRow = document.createElement('div')
-    statusRow.className = `recording-status status-${rec.status}`
+      const nameEl = document.createElement('span')
+      nameEl.className = 'recording-name'
+      nameEl.textContent = rec.displayName
+      nameEl.title = rec.caseTag
 
-    const dot = document.createElement('span')
-    dot.className = 'status-dot'
+      const countBadge = document.createElement('span')
+      countBadge.className = 'patient-count'
+      countBadge.textContent = rec.patients.length
 
-    const label = document.createElement('span')
-    label.textContent = rec.statusLabel
+      header.appendChild(nameEl)
+      header.appendChild(countBadge)
+      item.appendChild(header)
 
-    statusRow.appendChild(dot)
-    statusRow.appendChild(label)
-    item.appendChild(nameRow)
-    item.appendChild(statusRow)
+      rec.patients.forEach(patient => {
+        const patientRow = document.createElement('div')
+        patientRow.className = 'patient-row'
+
+        const patientName = document.createElement('div')
+        patientName.className = 'patient-name'
+        patientName.textContent = patient.name
+
+        const statusRow = document.createElement('div')
+        statusRow.className = `patient-status status-${patient.status}`
+
+        const dot = document.createElement('span')
+        dot.className = 'status-dot'
+
+        const label = document.createElement('span')
+        label.textContent = patient.statusLabel || patient.status
+
+        statusRow.appendChild(dot)
+        statusRow.appendChild(label)
+        patientRow.appendChild(patientName)
+        patientRow.appendChild(statusRow)
+        item.appendChild(patientRow)
+      })
+    } else {
+      // Single patient flat view
+      const nameRow = document.createElement('div')
+      nameRow.className = 'recording-name'
+      nameRow.textContent = rec.displayName
+      nameRow.title = rec.caseTag
+
+      const statusRow = document.createElement('div')
+      statusRow.className = `recording-status status-${rec.status}`
+
+      const dot = document.createElement('span')
+      dot.className = 'status-dot'
+
+      const label = document.createElement('span')
+      label.textContent = rec.statusLabel
+
+      statusRow.appendChild(dot)
+      statusRow.appendChild(label)
+      item.appendChild(nameRow)
+      item.appendChild(statusRow)
+    }
+
     list.appendChild(item)
   })
 }


### PR DESCRIPTION
When Claude detects multiple patients in a recording it creates per-patient
subfolders instead of a single top-level soap note. Previously this caused the
recording to be incorrectly marked as Failed in the status popup.

- Add detectPatientFolders() to scan the case dir for patient subfolders after
  Claude exits, rather than marking the recording as failed when the top-level
  soap note is absent
- Add setRecordingPatients() and updatePatientStatus() to track per-patient
  pipeline state; parent recording auto-completes when all patients are done
- Extend spawnDocxConversion() with an optional patientFolderName param so
  per-patient DOCX completions update the correct patient entry
- Add 'converting' status label for the DOCX conversion stage
- Status popup now renders a hierarchical view for multi-patient recordings:
    main (N)
      patient a  ● Converting...
      patient b  ● Completed
- Broadcast and get-session-recordings both include per-patient statusLabel
------
[fix: detect patient folders as siblings of caseDir and show correct n…](https://github.com/rishabh-navadhiti/pa-recording-app/commit/96c169501d462fc3872061b800dd1d4e57c1e473) 

…ames in notifications

- detectPatientFolders now scans sessionDir (parent of caseDir) to find patient sibling folders, skipping known case tags and already-claimed patients
- SOAP note notifications now show patient name or recording displayName instead of raw caseTag
- addRecordingEntry falls back to humanised caseTag when displayName is absent
- SKILL.md updated to place patient case dirs under SESSION_DIR to match new layout