### PR TITLE
feat: make popup and Session Status windows movable via drag handle

### DIFF
--- a/main.js
+++ b/main.js
@@ -46,6 +46,8 @@ let doctorPickerResolver = null
 let activeSessionDir = null
 let statusWin = null
 let sessionRecordings = []
+let userMovedPopup = false
+let isProgrammaticMove = false
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -184,8 +186,12 @@ function togglePopup() {
   if (win.isVisible()) {
     win.hide()
   } else {
-    const pos = getPopupPosition(tray, win)
-    win.setPosition(pos.x, pos.y, false)
+    if (!userMovedPopup) {
+      const pos = getPopupPosition(tray, win)
+      isProgrammaticMove = true
+      win.setPosition(pos.x, pos.y, false)
+      setImmediate(() => { isProgrammaticMove = false })
+    }
     win.show()
     win.focus()
   }
@@ -983,6 +989,10 @@ app.whenReady().then(async () => {
   })
 
   win.loadFile(path.join(__dirname, 'renderer', 'index.html'))
+
+  win.on('move', () => {
+    if (!isProgrammaticMove) userMovedPopup = true
+  })
 
   ipcMain.handle('hide-window', () => { if (win && !win.isDestroyed()) win.hide() })
 

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -12,6 +12,16 @@
     <!-- Header row (status + gear icon) -->
     <div id="header-row">
       <div id="status-row">
+        <span class="drag-handle" title="Drag to move">
+          <svg viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="1.5" cy="2" r="1" />
+            <circle cx="4.5" cy="2" r="1" />
+            <circle cx="1.5" cy="5" r="1" />
+            <circle cx="4.5" cy="5" r="1" />
+            <circle cx="1.5" cy="8" r="1" />
+            <circle cx="4.5" cy="8" r="1" />
+          </svg>
+        </span>
         <div id="indicator"></div>
         <span id="status-label">Loading...</span>
       </div>

--- a/renderer/status.css
+++ b/renderer/status.css
@@ -22,7 +22,7 @@ body {
 #status-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 8px;
   padding: 12px 16px;
   border-bottom: 1px solid #2a2a2a;
   flex-shrink: 0;
@@ -32,6 +32,35 @@ body {
   font-size: 13px;
   font-weight: 600;
   color: #e0e0e0;
+  flex: 1;
+  min-width: 0;
+}
+
+.drag-handle {
+  -webkit-app-region: drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 18px;
+  color: #777;
+  cursor: grab;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.drag-handle svg {
+  width: 6px;
+  height: 10px;
+  fill: currentColor;
+}
+
+.drag-handle:hover {
+  color: #ccc;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
 }
 
 .icon-btn {

--- a/renderer/status.html
+++ b/renderer/status.html
@@ -9,6 +9,16 @@
 <body>
   <div id="app">
     <div id="status-header">
+      <span class="drag-handle" title="Drag to move">
+        <svg viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="1.5" cy="2" r="1" />
+          <circle cx="4.5" cy="2" r="1" />
+          <circle cx="1.5" cy="5" r="1" />
+          <circle cx="4.5" cy="5" r="1" />
+          <circle cx="1.5" cy="8" r="1" />
+          <circle cx="4.5" cy="8" r="1" />
+        </svg>
+      </span>
       <span class="header-title">Session Status</span>
       <button id="btn-close" class="icon-btn" title="Close">&#10005;</button>
     </div>

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -36,6 +36,33 @@ body {
   flex-shrink: 0;
 }
 
+.drag-handle {
+  -webkit-app-region: drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 18px;
+  color: #777;
+  cursor: grab;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.drag-handle svg {
+  width: 6px;
+  height: 10px;
+  fill: currentColor;
+}
+
+.drag-handle:hover {
+  color: #ccc;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
 #btn-window-close {
   color: #aaa;
   font-size: 13px;


### PR DESCRIPTION
Adds a grip icon next to the status indicator in both windows. Once the user drags the popup, the auto-anchor logic that re-centered it on every show is suppressed for the rest of the session, so the popup stays where the user left it whether opened from the tray or Windows Search.