### PR TITLE
fix: handle cross-drive recording saves and non-NTFS docx paths

### DIFF
--- a/main.js
+++ b/main.js
@@ -874,8 +874,17 @@ function registerIpcHandlers() {
     const _stopTemplatePath = _stopDoctor?.templatePath || null
 
     if (fs.existsSync(tempMp3Path)) {
-      fs.renameSync(tempMp3Path, mp3Dest)
-      log(`MP3 moved to: ${mp3Dest}`)
+      try {
+        fs.copyFileSync(tempMp3Path, mp3Dest)
+        fs.unlinkSync(tempMp3Path)
+        log(`MP3 moved to: ${mp3Dest}`)
+      } catch (e) {
+        log(`ERROR moving MP3 from ${tempMp3Path} to ${mp3Dest}: ${e.message}`)
+        tempMp3Path = null
+        setState(STATE.SESSION_ACTIVE)
+        notifyUser('Recording failed', 'Could not save the recording. Check the log.')
+        return false
+      }
     } else {
       log(`WARNING: temp MP3 not found at ${tempMp3Path} — recording may have failed`)
     }

--- a/python/md_to_docx.py
+++ b/python/md_to_docx.py
@@ -203,7 +203,7 @@ def main():
         print("Usage: python3 md_to_docx.py <path_to_soap_note.md>", file=sys.stderr)
         sys.exit(1)
 
-    md_path = Path(sys.argv[1]).resolve()
+    md_path = Path(sys.argv[1]).absolute()
 
     if not md_path.exists():
         print(f"ERROR: File not found: {md_path}", file=sys.stderr)


### PR DESCRIPTION
When the notes folder is on a different drive than the system temp, fs.renameSync threw silently on cross-volume moves, leaving the app stuck in PROCESSING with no error and the captured audio lost. Replace with copyFileSync + unlinkSync wrapped in try/catch that logs, recovers state, and notifies the user on failure.

Also switch md_to_docx.py from Path.resolve() to Path.absolute() so docx generation works on volumes that don't implement GetFinalPathNameByHandle (e.g. VM shared folders that returned WinError 1005).

Refs #58