### PR TITLE
feat: reorder popup tabs to Record, Pre-chart, Templates

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -326,13 +326,13 @@
         <span class="tab-icon">&#9673;</span>
         <span>Record</span>
       </button>
-      <button id="btn-tab-templates" class="tab-btn" data-tab="templates">
-        <span class="tab-icon">&#128209;</span>
-        <span>Templates</span>
-      </button>
       <button id="btn-tab-prechart" class="tab-btn" data-tab="prechart">
         <span class="tab-icon">&#128221;</span>
         <span>Pre-chart</span>
+      </button>
+      <button id="btn-tab-templates" class="tab-btn" data-tab="templates">
+        <span class="tab-icon">&#128209;</span>
+        <span>Templates</span>
       </button>
     </div>
 


### PR DESCRIPTION
Moves Pre-chart before Templates in the bottom tab bar so the per-session Pre-chart action sits adjacent to Record.

Closes #61