### PR TITLE
feat: store ElevenLabs metrics in processing_events

### DIFF
--- a/db/events.js
+++ b/db/events.js
@@ -23,37 +23,42 @@ function finishEvent(eventId, {
   status,
   inputTokens, outputTokens, cacheReadTokens, cacheCreatedTokens,
   costUsd, numTurns, durationMs,
-  errorMessage, backupPath, finishedAt
+  errorMessage, backupPath, finishedAt,
+  transcriptLanguage, transcriptSpeakerCount
 }) {
   const db = getDb()
   if (!db || eventId == null) return
   try {
     const info = db.prepare(`
       UPDATE processing_events SET
-        status               = ?,
-        input_tokens         = ?,
-        output_tokens        = ?,
-        cache_read_tokens    = ?,
-        cache_created_tokens = ?,
-        cost_usd             = ?,
-        num_turns            = ?,
-        duration_ms          = ?,
-        error_message        = ?,
-        backup_path          = ?,
-        finished_at          = ?
+        status                   = ?,
+        input_tokens             = ?,
+        output_tokens            = ?,
+        cache_read_tokens        = ?,
+        cache_created_tokens     = ?,
+        cost_usd                 = ?,
+        num_turns                = ?,
+        duration_ms              = ?,
+        error_message            = ?,
+        backup_path              = ?,
+        finished_at              = ?,
+        transcript_language      = ?,
+        transcript_speaker_count = ?
       WHERE id = ?
     `).run(
       status,
-      inputTokens         ?? null,
-      outputTokens        ?? null,
-      cacheReadTokens     ?? null,
-      cacheCreatedTokens  ?? null,
-      costUsd             ?? null,
-      numTurns            ?? null,
-      durationMs          ?? null,
-      errorMessage        ? errorMessage.slice(0, 1024) : null,
-      backupPath          ?? null,
-      finishedAt          || new Date().toISOString(),
+      inputTokens              ?? null,
+      outputTokens             ?? null,
+      cacheReadTokens          ?? null,
+      cacheCreatedTokens       ?? null,
+      costUsd                  ?? null,
+      numTurns                 ?? null,
+      durationMs               ?? null,
+      errorMessage             ? errorMessage.slice(0, 1024) : null,
+      backupPath               ?? null,
+      finishedAt               || new Date().toISOString(),
+      transcriptLanguage       ?? null,
+      transcriptSpeakerCount   ?? null,
       eventId
     )
     if (info.changes === 0) {

--- a/db/migrations/006_elevenlabs_metrics.sql
+++ b/db/migrations/006_elevenlabs_metrics.sql
@@ -1,0 +1,5 @@
+-- ElevenLabs per-call metrics on processing_events.
+ALTER TABLE processing_events ADD COLUMN transcript_language      TEXT;
+ALTER TABLE processing_events ADD COLUMN transcript_speaker_count INTEGER;
+
+PRAGMA user_version = 6;

--- a/src/pipeline/elevenLabs.js
+++ b/src/pipeline/elevenLabs.js
@@ -13,9 +13,30 @@
 const fs   = require('fs')
 const path = require('path')
 
-const ELEVENLABS_API_URL = 'https://api.elevenlabs.io/v1/speech-to-text'
-const ELEVENLABS_MODEL   = 'scribe_v2'
-const DEFAULT_TIMEOUT_MS  = 300000  // matches transcribe.py's requests timeout=300
+const ELEVENLABS_API_URL         = 'https://api.elevenlabs.io/v1/speech-to-text'
+const ELEVENLABS_MODEL            = 'scribe_v2'
+const DEFAULT_TIMEOUT_MS          = 300000  // matches transcribe.py's requests timeout=300
+const SCRIBE_V2_COST_PER_HOUR_USD = 0.22   // verify at elevenlabs.io/pricing
+
+/**
+ * Extract per-call metrics from a raw ElevenLabs scribe_v2 response.
+ * All fields are nullable — callers can pass the result straight to finishEvent().
+ *
+ * @param {object} data  Parsed ElevenLabs JSON response.
+ * @returns {{ languageCode: string|null, speakerCount: number|null, audioDurationSeconds: number|null }}
+ */
+function extractTranscriptMetrics(data) {
+  const words = (data && data.words) || []
+  const speakerIds = new Set()
+  for (const w of words) {
+    if (w && w.type === 'word' && 'speaker_id' in w) speakerIds.add(w.speaker_id)
+  }
+  return {
+    languageCode:         (data && data.language_code)  ?? null,
+    speakerCount:         speakerIds.size > 0 ? speakerIds.size : null,
+    audioDurationSeconds: (data && data.audio_duration) ?? null,
+  }
+}
 
 /**
  * Build markdown from the words[] array returned by ElevenLabs. Groups
@@ -134,13 +155,16 @@ async function transcribeToFile(opts) {
   const markdown = formatTranscript(data)
   fs.mkdirSync(path.dirname(transcriptDest), { recursive: true })
   fs.writeFileSync(transcriptDest, markdown, 'utf8')
-  return { markdown }
+  const { languageCode, speakerCount, audioDurationSeconds } = extractTranscriptMetrics(data)
+  return { markdown, languageCode, speakerCount, audioDurationSeconds }
 }
 
 module.exports = {
   formatTranscript,
+  extractTranscriptMetrics,
   requestTranscription,
   transcribeToFile,
   ELEVENLABS_API_URL,
   ELEVENLABS_MODEL,
+  SCRIBE_V2_COST_PER_HOUR_USD,
 }

--- a/src/pipeline/transcription.js
+++ b/src/pipeline/transcription.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { ELEVENLABS_AUTH_ERROR, ELEVENLABS_RATE_LIMITED } = require('../llm/skill-io/markers')
-const { transcribeToFile } = require('./elevenLabs')
+const { transcribeToFile, ELEVENLABS_MODEL, SCRIBE_V2_COST_PER_HOUR_USD } = require('./elevenLabs')
 
 /**
  * Transcribe an MP3 via ElevenLabs (in-process, Node — see elevenLabs.js) and
@@ -22,6 +22,15 @@ const { transcribeToFile } = require('./elevenLabs')
  *                                         Typically triggers SOAP generation.
  * @param {Function} opts.spawnDocx        spawnDocxConversion(mdPath, caseTag, null, caseId) — for transcript.docx.
  */
+// Parse cases.audio_duration ('HH:MM:SS' string) back to seconds for cost calculation.
+function parseHHMMSS(raw) {
+  if (raw == null) return null
+  if (typeof raw === 'number') return raw
+  const parts = String(raw).split(':').map(Number)
+  if (parts.length !== 3 || parts.some(isNaN)) return null
+  return parts[0] * 3600 + parts[1] * 60 + parts[2]
+}
+
 function spawnTranscription({ mp3Path, transcriptDest, soapNotePath, caseTag, templatePath, caseId, ctx, onSuccess, spawnDocx }) {
   const { log } = ctx
   const tag = caseTag ? `[${caseTag}] ` : ''
@@ -31,7 +40,7 @@ function spawnTranscription({ mp3Path, transcriptDest, soapNotePath, caseTag, te
   let eventId = null
   try {
     const { dbEvents } = requireDb()
-    eventId = dbEvents.startEvent({ caseId, jobKind: 'transcribe', startedAt })
+    eventId = dbEvents.startEvent({ caseId, jobKind: 'transcribe', modelUsed: ELEVENLABS_MODEL, startedAt })
   } catch (e) { log(`[db] startEvent(transcribe) failed: ${e.message}`) }
 
   log(`${tag}Transcription started for: ${mp3Path}`)
@@ -43,7 +52,7 @@ function spawnTranscription({ mp3Path, transcriptDest, soapNotePath, caseTag, te
       if (!apiKey) throw new Error('ELEVENLABS_API_KEY not configured')
       return transcribeToFile({ mp3Path, transcriptDest, apiKey })
     })
-    .then(() => {
+    .then(({ languageCode, speakerCount, audioDurationSeconds }) => {
       // Transcription itself succeeded — record it. The post-success callbacks
       // (SOAP gen + transcript docx) run in the FINAL .then below, OUTSIDE the
       // .catch — so a synchronous throw in their setup is a SOAP/docx defect, not
@@ -51,8 +60,21 @@ function spawnTranscription({ mp3Path, transcriptDest, soapNotePath, caseTag, te
       log(`${tag}[transcribe] completed`)
       const durationMs = Date.now() - wallStart
       const { dbEvents, dbCases } = requireDb()
+      // ElevenLabs doesn't return audio_duration; read cases.audio_duration instead.
+      // That column stores a formatted 'HH:MM:SS' string (see db/cases.js formatDuration).
+      const rawDuration = audioDurationSeconds
+        ?? (caseId ? (dbCases.getCaseRow(caseId) || {}).audio_duration : null)
+      const resolvedDuration = parseHHMMSS(rawDuration)
+      const costUsd = resolvedDuration != null
+        ? (resolvedDuration / 3600) * SCRIBE_V2_COST_PER_HOUR_USD
+        : null
       try {
-        dbEvents.finishEvent(eventId, { status: 'success', durationMs, finishedAt: new Date().toISOString() })
+        dbEvents.finishEvent(eventId, {
+          status: 'success', durationMs, finishedAt: new Date().toISOString(),
+          costUsd,
+          transcriptLanguage:     languageCode,
+          transcriptSpeakerCount: speakerCount,
+        })
         dbCases.updateCasePaths(caseId, { status: 'generating_note', transcript_path: transcriptDest })
       } catch (e) { log(`[db] transcribe success update failed: ${e.message}`) }
       return true

--- a/tests/unit/transcription.test.js
+++ b/tests/unit/transcription.test.js
@@ -13,8 +13,10 @@ const path = require('path')
 
 const {
   formatTranscript,
+  extractTranscriptMetrics,
   requestTranscription,
   transcribeToFile,
+  SCRIBE_V2_COST_PER_HOUR_USD,
 } = require('../../src/pipeline/elevenLabs')
 const { ELEVENLABS_AUTH_ERROR, ELEVENLABS_RATE_LIMITED } = require('../../src/llm/skill-io/markers')
 
@@ -23,6 +25,7 @@ const { ELEVENLABS_AUTH_ERROR, ELEVENLABS_RATE_LIMITED } = require('../../src/ll
 // Speaker-N label must be reused, not re-numbered).
 const SAMPLE = {
   language_code: 'en',
+  audio_duration: 120.5,
   text: 'Hello doctor Hi there Back',
   words: [
     { text: 'Hello',  type: 'word',    speaker_id: 'speaker_0', start: 0.1, end: 0.5 },
@@ -82,10 +85,43 @@ test('transcribeToFile writes the formatted markdown to disk', async () => {
     return { ok: true, status: 200, json: async () => SAMPLE }
   }
 
-  const { markdown } = await transcribeToFile({ mp3Path: mp3, transcriptDest: dest, apiKey: 'k-123', fetchImpl })
+  const { markdown, languageCode, speakerCount, audioDurationSeconds } = await transcribeToFile({ mp3Path: mp3, transcriptDest: dest, apiKey: 'k-123', fetchImpl })
   assert.strictEqual(markdown, GOLDEN)
   assert.strictEqual(fs.readFileSync(dest, 'utf8'), GOLDEN)
+  assert.strictEqual(languageCode, 'en')
+  assert.strictEqual(speakerCount, 2)
+  assert.strictEqual(audioDurationSeconds, 120.5)
   fs.rmSync(dir, { recursive: true, force: true })
+})
+
+test('extractTranscriptMetrics returns language, speaker count, and audio duration', () => {
+  const m = extractTranscriptMetrics(SAMPLE)
+  assert.strictEqual(m.languageCode, 'en')
+  assert.strictEqual(m.speakerCount, 2)
+  assert.strictEqual(m.audioDurationSeconds, 120.5)
+})
+
+test('extractTranscriptMetrics returns nulls when fields are absent', () => {
+  const m = extractTranscriptMetrics({ words: [] })
+  assert.strictEqual(m.languageCode, null)
+  assert.strictEqual(m.speakerCount, null)
+  assert.strictEqual(m.audioDurationSeconds, null)
+})
+
+test('extractTranscriptMetrics ignores spacing tokens when counting speakers', () => {
+  const m = extractTranscriptMetrics({
+    language_code: 'en',
+    audio_duration: 10,
+    words: [
+      { type: 'spacing', speaker_id: 'speaker_0', text: ' ' },
+      { type: 'word',    speaker_id: 'speaker_0', text: 'Hi' },
+    ],
+  })
+  assert.strictEqual(m.speakerCount, 1)
+})
+
+test('SCRIBE_V2_COST_PER_HOUR_USD is a positive number', () => {
+  assert.ok(typeof SCRIBE_V2_COST_PER_HOUR_USD === 'number' && SCRIBE_V2_COST_PER_HOUR_USD > 0)
 })
 
 test('requestTranscription throws an auth-classifiable error on 401', async () => {


### PR DESCRIPTION
- Add migration 006 to add transcript_language and transcript_speaker_count columns to processing_events
- Extract per-call metrics (language, speaker count, audio duration) from ElevenLabs scribe_v2 response via extractTranscriptMetrics()
- Store model_used='scribe_v2' on transcribe events
- Calculate cost_usd from cases.audio_duration (HH:MM:SS parsed to seconds) at $0.22/hr since ElevenLabs does not return audio_duration in response
- Add 4 unit tests covering extractTranscriptMetrics and cost constant