### PR TITLE
fix(costigan): render objectified fields as text; fix within_cap pill

### DIFF
--- a/src/render/costiganHtml.js
+++ b/src/render/costiganHtml.js
@@ -57,7 +57,29 @@ const MARK_SVG = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none"><p
 const FA_IC = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M13 3L4 14h6l-1 7 9-11h-6l1-7z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/></svg>'
 
 // ---- helpers ----
-const esc = (s) => String(s == null ? '' : s)
+// Coerce any model-provided value to display text. The Costigan model output is
+// non-deterministic: fields the schema lists as string arrays (coding_issues,
+// evidence_found, …) sometimes come back as objects, e.g. a coding issue as
+// { issue, linked_proc_id }. Without this, esc() would stringify them to the
+// literal "[object Object]". Pull the human-readable field (prefixing a code when
+// present so nothing is lost); arrays are joined; primitives pass through.
+function asText(v) {
+  if (v == null) return ''
+  if (typeof v === 'string') return v
+  if (typeof v !== 'object') return String(v)
+  if (Array.isArray(v)) return v.map(asText).filter(Boolean).join('; ')
+  for (const k of ['issue', 'text', 'description', 'desc', 'note', 'message', 'detail', 'reason', 'value', 'label']) {
+    if (typeof v[k] === 'string' && v[k].trim()) {
+      return (typeof v.code === 'string' && v.code.trim()) ? `${v.code} — ${v[k]}` : v[k]
+    }
+  }
+  if (typeof v.code === 'string' && v.code.trim()) return v.code
+  return Object.values(v).filter(x => typeof x === 'string' && x.trim()).join(' — ')
+}
+
+// esc() routes through asText() first, so EVERY interpolation in this file is
+// object-safe — an objectified field renders as readable text, never "[object Object]".
+const esc = (s) => asText(s)
   .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
   .replace(/"/g, '&quot;').replace(/'/g, '&#39;')
 const has = (v) => v !== null && v !== undefined && v !== ''
@@ -110,7 +132,7 @@ function renderCoding(c) {
   const lines = []
   if (cpt.length)    lines.push(`<div class="codechips">${cpt.map(x => codechip(x)).join('')}</div>`)
   if (icdObs.length) lines.push(`<div class="codechips">${icdObs.map(x => codechip(x)).join('')}</div>`)
-  if (icdSug.length) lines.push(`<div class="codechips">${icdSug.map(s => codechip(s.code, s.description, true)).join('')}</div>`)
+  if (icdSug.length) lines.push(`<div class="codechips">${icdSug.map(s => typeof s === 'string' ? codechip(s, '', true) : codechip(s.code, s.description, true)).join('')}</div>`)
   if (issues.length) lines.push(`<ul class="issues-list">${issues.map(i => `<li>${esc(i)}</li>`).join('')}</ul>`)
   return `<div class="card proc-block"><h3>Coding</h3>${lines.join('')}</div>`
 }
@@ -123,9 +145,13 @@ function renderFrequency(f) {
   if (!has(f.cap) && !priors.length && !hasWithin && !has(f.note)) return ''
   let pill = ''
   if (hasWithin) {
-    const v = f.within_cap
-    const label = v === true ? 'Within cap' : v === false ? 'Over cap' : cap(v)
-    const cls = v === true ? 'good' : v === false ? 'crit' : 'warn'
+    // within_cap is a string per the skill schema ("true|false|unclear") but may
+    // also arrive as a real boolean — handle both.
+    const norm = String(f.within_cap).trim().toLowerCase()
+    const within = f.within_cap === true || norm === 'true'
+    const over = f.within_cap === false || norm === 'false'
+    const label = within ? 'Within cap' : over ? 'Over cap' : norm === 'unclear' ? 'Unclear' : cap(asText(f.within_cap))
+    const cls = within ? 'good' : over ? 'crit' : 'warn'
     pill = `<span class="freq-pill ${cls}">${esc(label)}</span>`
   }
   const lines = []
@@ -146,7 +172,7 @@ function renderProcedureSection(p, idx) {
   if (has(p.site))   meta.push(`<span class="meta-item"><span class="mi-lbl">Site</span>${esc(p.site)}</span>`)
   const metaHtml = meta.length ? `<div class="fc-meta">${meta.join('')}</div>` : ''
 
-  const denial = (p.verdict === 'likely_denied' && has(p.denial_reason))
+  const denial = (p.verdict === 'likely_denied' && has(asText(p.denial_reason)))
     ? `<div class="fc-action"><span class="fa-ic">${FA_IC}</span><span class="fa-txt"><span class="fa-kicker">Denial risk</span>${esc(p.denial_reason)}</span></div>`
     : ''
 
@@ -240,7 +266,7 @@ function renderCostiganHtml(data) {
     + `<div class="fb-num">${esc(b.n)}</div><div class="fb-lbl">${esc(b.label)}</div></div>`).join('')
 
   const calloutCls = ov.led === 'good' ? 'callout' : ov.led === 'crit' ? 'callout crit' : 'callout alert'
-  const headlineHtml = has(summary.headline)
+  const headlineHtml = has(asText(summary.headline))
     ? `<div class="${calloutCls}" style="margin-bottom:18px"><span class="co-ic">${ov.led === 'good' ? '✓' : '⚠'}</span><span class="co-body">${esc(summary.headline)}</span></div>`
     : ''
 

--- a/tests/unit/costiganHtml.test.js
+++ b/tests/unit/costiganHtml.test.js
@@ -54,9 +54,14 @@ test('within_cap tri-state: true -> Within cap, false -> Over cap, "unclear" -> 
     summary: { procedures_in_play: 1, overall_status: 'likely_denied', likely_denied_count: 1 },
     procedures_detected: [{ procedure: 'TPI', verdict: 'likely_denied', checklist: [], coding: {}, frequency: { cap: '', prior_dates: [], within_cap: within } }],
   })
+  // booleans (defensive) …
   assert.ok(mk(true).includes('Within cap'))
   assert.ok(mk(false).includes('Over cap'))
   assert.ok(mk('unclear').includes('Unclear'))
+  // … and the string forms the skill schema actually emits ("true|false|unclear")
+  assert.ok(mk('true').includes('Within cap'), 'string "true" -> Within cap')
+  assert.ok(!mk('true').includes('>TRUE<'), 'string "true" not shown as raw TRUE')
+  assert.ok(mk('false').includes('Over cap'), 'string "false" -> Over cap')
 })
 
 test('renders denial-risk callout for likely_denied procedures', () => {
@@ -84,6 +89,35 @@ test('escapes clinical free text containing < & " so markup cannot break', () =>
   assert.ok(html.includes('&lt;Co&gt;'))
   assert.ok(html.includes('pain &lt;50% &amp; &quot;stable&quot;'))
   assert.ok(html.includes('fix &lt;this&gt; &amp; &quot;that&quot;'))
+})
+
+test('coerces objectified array fields to text (no [object Object])', () => {
+  // The model sometimes returns coding_issues / evidence_found as objects rather
+  // than strings (e.g. a coding issue as {issue, linked_proc_id}). The renderer
+  // must show the readable text, never the literal "[object Object]".
+  const html = renderCostiganHtml({
+    meta: { patient: 'P' },
+    summary: { procedures_in_play: 1, overall_status: 'needs_edits', needs_edits_count: 1 },
+    procedures_detected: [{
+      procedure: 'ESI', verdict: 'needs_edits',
+      checklist: [{ id: 'ESI-1', criterion: 'c', status: 'unclear',
+        evidence_found: [{ text: 'MRI shows stenosis' }], fix: 'do x' }],
+      coding: {
+        cpt_observed: [{ code: '64483' }],
+        icd_suggested: [{ code: 'M54.17', description: 'Radiculopathy' }],
+        coding_issues: [
+          { issue: 'No codes were stated in the note', linked_proc_id: 'proc-001' },
+          { code: 'M51.36', issue: 'non-billable header' },
+        ],
+      },
+      frequency: {},
+    }],
+  })
+  assert.ok(!html.includes('[object Object]'), 'no [object Object] anywhere')
+  assert.ok(html.includes('No codes were stated in the note'), 'object issue text rendered')
+  assert.ok(html.includes('M51.36 — non-billable header'), 'code-prefixed issue rendered')
+  assert.ok(html.includes('MRI shows stenosis'), 'object evidence text rendered')
+  assert.ok(html.includes('64483'), 'object cpt code rendered')
 })
 
 test('output is offline / has no external resource references', () => {


### PR DESCRIPTION
Two report-rendering fixes:

1. The model sometimes returns string-array fields (e.g. coding_issues) as objects like {issue, linked_proc_id}; esc() stringified them to the literal [object Object]. Add an asText() coercion and route esc() through it, so every interpolation renders readable text (code-bearing issues as 'code - text').

2. within_cap is a string per the skill schema ('true|false|unclear') but was compared to the boolean true/false, so it never matched and always showed an amber uppercased word (e.g. TRUE). Handle the string forms -> green 'Within cap' / red 'Over cap' / amber 'Unclear'.

Adds regression tests for object-shaped coding_issues/evidence_found and the within_cap string forms.